### PR TITLE
fix: Correct trading loop and data handling bugs

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -692,28 +692,20 @@ class TradingPage(ttk.Frame):
                         self._ui_queue.put((self._log, (f"Error closing positions: {e}",)))
                     self.batch_start_equity = equity
                     self.current_batch_trades = 0
-                else:
-                    time.sleep(1)
-                    continue
+                # BUG FIX: Removed the `else...continue` which would halt trading if the
+                # profit target was not met after the batch size was reached.
 
             print("Fetching tick price...")
             current_tick_price = self.trader.get_market_price(symbol)
             print(f"Tick price: {current_tick_price}")
 
-            # Fetch OHLC
+            # Fetch OHLC data. Data is already prepared in trading.py
             ohlc_1m_df = self.trader.ohlc_history.get('1m', pd.DataFrame())
             
-            if (
-                isinstance(ohlc_1m_df, pd.DataFrame)
-                and not ohlc_1m_df.empty
-                and 'timestamp' in ohlc_1m_df.columns
-                and isinstance(ohlc_1m_df.index, pd.RangeIndex)
-            ):
-                try:
-                    ohlc_1m_df['timestamp'] = pd.to_datetime(ohlc_1m_df['timestamp'], utc=True)
-                    ohlc_1m_df.set_index('timestamp', inplace=True)
-                except Exception as e:
-                    print(f"Error during timestamp normalization: {e}")
+            # BUG FIX: Removed redundant and buggy dataframe processing.
+            # The dataframe from trader.ohlc_history is already indexed by timestamp.
+            # The previous logic would fail after the first trade because the index
+            # was no longer a RangeIndex.
 
             # Strategy decision
             action_details = strategy.decide({


### PR DESCRIPTION
This commit fixes two critical bugs in the trading loop (`_scalp_loop` in `gui.py`) that prevented the application from trading continuously.

1.  **OHLC Data Handling Bug:**
    - The code that prepares the historical OHLC data for the strategy was failing after the first trade. This was because it was incorrectly trying to process a dataframe that was already correctly formatted by the `trading.py` module.
    - This bug caused the application to stop finding new trading opportunities after the first trade.
    - The fix involves removing the redundant and buggy data processing block, allowing the correctly formatted data to be passed to the strategy on every loop iteration.

2.  **Batch Trading Logic Bug:**
    - The logic for handling trade batches would cause the trading loop to stall if the batch size was reached but the profit target was not.
    - The loop would get stuck in a state where it would continuously check the profit target without ever looking for new trades.
    - The fix removes the faulty `else...continue` statement, allowing the loop to proceed normally.