### PR TITLE
fix: Resolve NameError in gui.py

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,7 +3,7 @@ import threading
 import tkinter as tk
 import queue
 from tkinter import ttk, messagebox, simpledialog
-from typing import List # Added for type hinting
+from typing import List, Dict, Any # Added for type hinting
 import pandas as pd # Added for OHLC data handling
 from trading import Trader, AiAdvice # adjust import path if needed
 from strategies import (
@@ -14,8 +14,6 @@ from indicators import (
     calculate_ema, calculate_atr, calculate_rsi, calculate_adx
 )
 from ttkthemes import ThemedTk
-
-from typing import Dict
 
 class MainApplication(ThemedTk):
     def __init__(self, settings):


### PR DESCRIPTION
This commit fixes a `NameError: name 'Any' is not defined` that occurred when running the application.

The error was caused by using the `Any` and `Dict` type hints from the `typing` module without importing them. This commit adds `Any` and `Dict` to the import statement at the top of `gui.py` and removes a duplicate import of `Dict`.

## Summary by Sourcery

Fix NameError in gui.py by importing Any and Dict from typing and removing the duplicate Dict import.

Bug Fixes:
- Add missing imports for Any and Dict in gui.py to fix NameError
- Remove redundant import of Dict from typing